### PR TITLE
Bootloader: Add Reading of Git SHA to bootloader

### DIFF
--- a/Tools/AP_Bootloader/AP_Bootloader.cpp
+++ b/Tools/AP_Bootloader/AP_Bootloader.cpp
@@ -39,6 +39,10 @@
 #include <AP_CheckFirmware/AP_CheckFirmware.h>
 #include "network.h"
 
+#define FORCE_VERSION_H_INCLUDE
+#include "ap_version.h"
+#undef FORCE_VERSION_H_INCLUDE
+
 extern "C" {
     int main(void);
 }
@@ -47,7 +51,8 @@ struct boardinfo board_info = {
     .board_type = APJ_BOARD_ID,
     .board_rev = 0,
     .fw_size = (BOARD_FLASH_SIZE - (FLASH_BOOTLOADER_LOAD_KB + FLASH_RESERVE_END_KB + APP_START_OFFSET_KB))*1024,
-    .extf_size = (EXT_FLASH_SIZE_MB * 1024 * 1024) - (EXT_FLASH_RESERVE_START_KB + EXT_FLASH_RESERVE_END_KB) * 1024
+    .extf_size = (EXT_FLASH_SIZE_MB * 1024 * 1024) - (EXT_FLASH_RESERVE_START_KB + EXT_FLASH_RESERVE_END_KB) * 1024,
+    .git_hash = GIT_VERSION_INT
 };
 
 #ifndef HAL_BOOTLOADER_TIMEOUT

--- a/Tools/AP_Bootloader/bl_protocol.cpp
+++ b/Tools/AP_Bootloader/bl_protocol.cpp
@@ -83,7 +83,7 @@
 // RESET		finalise flash programming, reset chip and starts application
 //
 
-#define BL_PROTOCOL_VERSION 		5		// The revision of the bootloader protocol
+#define BL_PROTOCOL_VERSION 		6		// The revision of the bootloader protocol
 // protocol bytes
 #define PROTO_INSYNC				0x12    // 'in sync' byte sent before status
 #define PROTO_EOC					0x20    // end of command
@@ -128,6 +128,7 @@
 #define PROTO_DEVICE_FW_SIZE	4	// size of flashable area
 #define PROTO_DEVICE_VEC_AREA	5	// contents of reserved vectors 7-10
 #define PROTO_DEVICE_EXTF_SIZE  6   // size of available external flash
+#define PROTO_DEVICE_BL_GIT_HASH 7  // git hash of bootloader build
 // all except PROTO_DEVICE_VEC_AREA and PROTO_DEVICE_BOARD_REV should be done
 #define CHECK_GET_DEVICE_FINISHED(x)   ((x & (0xB)) == 0xB)
 
@@ -601,6 +602,10 @@ bootloader(unsigned timeout)
 
             case PROTO_DEVICE_EXTF_SIZE:
                 cout((uint8_t *)&board_info.extf_size, sizeof(board_info.extf_size));
+                break;
+            
+            case PROTO_DEVICE_BL_GIT_HASH:
+                cout((uint8_t *)&board_info.git_hash, sizeof(board_info.git_hash));
                 break;
 
             default:

--- a/Tools/AP_Bootloader/support.h
+++ b/Tools/AP_Bootloader/support.h
@@ -9,6 +9,7 @@ struct boardinfo {
     uint32_t	board_rev;
     uint32_t	fw_size;
     uint32_t    extf_size;
+    uint32_t    git_hash;
 } __attribute__((packed));
 
 extern struct boardinfo board_info;

--- a/Tools/AP_Bootloader/wscript
+++ b/Tools/AP_Bootloader/wscript
@@ -10,6 +10,8 @@ def build(bld):
     else:
         flashiface_lib = []
 
+    _build_dynamic_sources(bld)
+
     bld.ap_stlib(
         name= 'AP_Bootloader_libs',
         use='dronecan',
@@ -34,3 +36,19 @@ def build(bld):
         use=['AP_Bootloader_libs', 'libcanard', 'dronecan'],
         program_groups='bootloader'
     )
+
+def _build_dynamic_sources(bld):
+    def write_version_header(tsk):
+        bld = tsk.generator.bld
+        return bld.write_version_header(tsk.outputs[0].abspath())
+
+    bld(
+        name='ap_version',
+        target='ap_version.h',
+        vars=['AP_VERSION_ITEMS'],
+        rule=write_version_header,
+    )
+
+    bld.env.prepend_value('INCLUDES', [
+        bld.bldnode.abspath(),
+    ])

--- a/Tools/scripts/uploader.py
+++ b/Tools/scripts/uploader.py
@@ -239,11 +239,12 @@ class uploader(object):
 
     INFO_BL_REV     = b'\x01'        # bootloader protocol revision
     BL_REV_MIN      = 2              # minimum supported bootloader protocol
-    BL_REV_MAX      = 5              # maximum supported bootloader protocol
+    BL_REV_MAX      = 6              # maximum supported bootloader protocol
     INFO_BOARD_ID   = b'\x02'        # board type
     INFO_BOARD_REV  = b'\x03'        # board revision
     INFO_FLASH_SIZE = b'\x04'        # max firmware size in bytes
     INFO_EXTF_SIZE  = b'\x06'        # available external flash size
+    INFO_GIT_HASH   = b'\x07'        # git hash of bootloader build
 
     PROG_MULTI_MAX  = 252            # protocol max is 255, must be multiple of 4
     READ_MULTI_MAX  = 252            # protocol max is 255
@@ -737,6 +738,10 @@ class uploader(object):
         self.board_rev = self.__getInfo(uploader.INFO_BOARD_REV)
         self.fw_maxsize = self.__getInfo(uploader.INFO_FLASH_SIZE)
 
+        # Git SHA introduced added in v6
+        if self.bl_rev > 5: 
+            self.git_hash = self.__getInfo(uploader.INFO_GIT_HASH)
+
     def dump_board_info(self):
         # OTP added in v4:
         print("Bootloader Protocol: %u" % self.bl_rev)
@@ -838,6 +843,9 @@ class uploader(object):
         else:
             print("  board_type: %u" % self.board_type)
         print("  board_rev: %u" % self.board_rev)
+
+        git_hash = "%x" % (self.git_hash) if self.bl_rev > 5 else "UNKNOWN"
+        print("  git hash: %s" % git_hash)
 
         print("Identification complete")
 


### PR DESCRIPTION
Allows the bootloader build to be identified with `uploader.py`